### PR TITLE
Fixes bug with evValidable

### DIFF
--- a/core/js/directives/ValidableDirective.js
+++ b/core/js/directives/ValidableDirective.js
@@ -4,7 +4,7 @@ var module = angular.module('ev-fdm')
  * TO DO: expose makeValidable, to provides validation directly
  * on focus or on when a key is entered
  */
-.directive('evValidable', ['$timeout', function ($timeout) {
+.directive('evValidable', function () {
     return {
         restrict: 'A',
         require: ['ngModel', '^evSubmit', '^?evFormGroup'],
@@ -48,4 +48,4 @@ var module = angular.module('ev-fdm')
             });
         }
     };
-}]);
+});

--- a/core/js/directives/ValidableDirective.js
+++ b/core/js/directives/ValidableDirective.js
@@ -4,7 +4,7 @@ var module = angular.module('ev-fdm')
  * TO DO: expose makeValidable, to provides validation directly
  * on focus or on when a key is entered
  */
-.directive('evValidable', function () {
+.directive('evValidable', ['$timeout', function ($timeout) {
     return {
         restrict: 'A',
         require: ['ngModel', '^evSubmit', '^?evFormGroup'],
@@ -13,28 +13,39 @@ var module = angular.module('ev-fdm')
                 evSubmit = controllers[1],
                 evFormGroup = controllers[2];
 
-            var makeValidable = function() {
-                model.evValidable = true;
-                hasError();
+            var markAsBlurred = function() {
+                model.evBlurred = true;
             };
 
-            var hasError = function() {
-                model.evHasError = !!(!model.$valid && model.evValidable);
+            var markAsChanged = function() {
+                model.evChanged = true;
+            };
+
+            var displayErrors = function() {
+                model.evHasError = !!(!model.$valid && model.evBlurred && model.evChanged);
 
                 if (evFormGroup) {
                     evFormGroup.toggleError(model.evHasError);
                 }
             };
 
-            evSubmit.$addValidable(makeValidable);
-
             element.on('blur', function() {
-                scope.$apply(makeValidable);
+                scope.$evalAsync(function() {
+                    markAsBlurred();
+                    displayErrors();
+                });
             });
 
-            element.on('keyup', function() {
-                scope.$apply(hasError);
+            model.$viewChangeListeners.push(function() {
+                markAsChanged();
+                displayErrors();
+            });
+
+            evSubmit.$addValidable(function() {
+                markAsBlurred();
+                markAsChanged();
+                displayErrors();
             });
         }
     };
-});
+}]);


### PR DESCRIPTION
Two issues are fixed here :
* The directive was relying on $scope.$apply, which is an issue when a non angular composant is used (ui-date for instance) because the composant already triggers a digest cycle.
* Some non angular composant trigger blur before changing the view value (ui-date for instance...) and error message was displayed for a little amount of time until new value was set. Now for a message to be displayed we need blur and setViewValue to have been called.

![obliviate that day...](http://media.giphy.com/media/PcfozPlZSzARO/giphy.gif)
