### PR TITLE
chores: remove git URL in ui-router version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "jquery": "~2.0.3",
     "angular": "1.2.18",
-    "angular-ui-router": "git@github.com:Evaneos/ui-router#view-prevent-update",
+    "angular-ui-router": "Evaneos/ui-router#view-prevent-update",
     "angular-animate": "1.2.18",
     "angular-ui-select2": "~0.0.2",
     "angular-loading-bar": "~0.6.0",


### PR DESCRIPTION
## Description

In order to avoid dependencies _fetching_, we remove the `git` protocol & `github.com` prefix [[SO thread](https://stackoverflow.com/a/20314313/4807620)]

Error we face:

> Failed to execute "git ls-remote --tags --heads git@github.com:Evaneos/ui-router.git", exit code of #128 error: cannot run ssh: No such file or directory fatal: unable to fork