### PR TITLE
security: protect against npm supply chain attacks (INC-227)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply chain protection (ref INC-227)
+# Refuse to install packages published after this date.
+# To upgrade dependencies, bump this date to no later than today - 7 days.
+before=2026-05-04

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ and you are good to go !
 At the root of the project, run
 
     make watch
+
+## Supply chain protection
+
+This repo pins npm installs to packages published before a fixed date via the `before` directive in `.npmrc`, as a mitigation against npm supply chain attacks (ref INC-227).
+
+**If you need to upgrade dependencies**, update the `before` date in `.npmrc` to a value at most today minus 7 days. This 7-day delay leaves time for the community and automated scanners to detect and unpublish compromised packages before they reach our install.


### PR DESCRIPTION
## Context

Mitigation for supply chain attacks on npm packages — ref [INC-227](https://www.notion.so/337a9700660280cab808ea74341992b1).

Node version in this repo (`` from ) is below 24.14.1, which is required for `min-release-age`. As an alternative mitigation we use the `before` directive: npm will refuse to install any package version published after the configured date.

## Changes

- Add `before=2026-05-04` to `.npmrc` (today − 7 days)
- Add a "Supply chain protection" section to `README.md` explaining how to update the date when bumping dependencies

## How to upgrade dependencies later

Update the `before` date in `.npmrc` to a value at most `today − 7 days`. The 7-day buffer lets the community detect and unpublish compromised packages before they end up in our install.
